### PR TITLE
Fork changes for iOS only approach when existing Firebase Android already exists in App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+build/

--- a/README.md
+++ b/README.md
@@ -9,3 +9,104 @@ Take a look at the [documentation](push/README.md) in the "app facing package" (
 ## Contributing
 
 Take a look at the [contributing](CONTRIBUTING.md) guide.
+
+# Fork Changes for iOS Only (when using Firebase for Android)
+These are the changes made for iOS Only
+
+## Adding forked package to your <project>
+Added to a project's `packages/` folder as a submodule with these standard git commands:
+```
+# assuming packages/ folder
+cd <project>/packages;
+
+# clone it as a submodule
+git submodule add git@github.com:sonjz/push;
+
+# NOTE: if you ever do a fresh clone you need to initialize submodule
+git submodule update --init;
+
+```
+
+## Disabling non-iOS platforms and enabling Local Packages
+In `push/pubspec.yaml` I've removed `push_android` and `push_macos` as they are no longer required libraries.  But since this is a fork we are using locally, we need to reference the local package vs ones that would be fetched from pub.dev.
+
+@ben-xD also mentioned this comment that changing defaults for plugins (like removing Android) is in the works by flutter.
+https://github.com/ben-xD/push/issues/61#issuecomment-2141618459
+
+```
+# push/pubspec.yaml
+...
+
+# had to add this as it was complaining
+publish_to: none
+
+...
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # Federated package dependencies
+  #push_platform_interface: ^0.6.0
+  #push_android: ^0.6.0
+  #push_ios: ^0.5.1
+  #push_macos: ^0.0.1
+  # End of federated package dependencies
+
+  # When developing push locally, make sure
+  # For example, I often make the mistake where I update the local cache
+  # of published push_ios, then try and run the app using the local push_ios.
+  # My changes don't get to run.
+  # A huge pain of federated packages.
+
+  # Local development dependencies -
+  # uncomment this and comment out the federated package dependencies
+  push_platform_interface:
+    path: "../push_platform_interface"
+  # push_android:
+  #   path: "../push_android"
+  push_ios:
+    path: "../push_ios"
+  # push_macos:
+  #   path: "../push_macos"
+# End of local development dependencies
+
+...
+
+flutter:
+  uses-material-design: false
+  plugin:
+    platforms:
+      #android:
+      #  default_package: push_android
+      ios:
+        default_package: push_ios
+
+...
+```
+
+Additionally in `push_ios` we had to reference locally as well.
+```
+# push_ios/pubspec.yaml
+...
+
+# had to add this as it was complaining
+publish_to: none
+
+...
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # Federated package dependencies
+  # push_platform_interface: ^0.6.0
+
+  # Local development dependencies
+  push_platform_interface:
+    path: "../push_platform_interface"
+  # End of local dependencies
+
+...
+```
+

--- a/push/example/lib/main.dart
+++ b/push/example/lib/main.dart
@@ -44,8 +44,8 @@ class MyApp extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final notificationWhichLaunchedApp = useState<Map<String?, Object?>?>(null);
-    final messagesReceived = useState<List<RemoteMessage>>([]);
-    final backgroundMessagesReceived = useState<List<RemoteMessage>>([]);
+    final messagesReceived = useState<List<RemoteMessage1>>([]);
+    final backgroundMessagesReceived = useState<List<RemoteMessage1>>([]);
     final tappedNotificationPayloads =
         useState<List<Map<String?, Object?>>>([]);
     final isForegroundNotificationsEnabled = useState(true);

--- a/push/example/lib/remote_message_widget.dart
+++ b/push/example/lib/remote_message_widget.dart
@@ -3,7 +3,7 @@ import 'package:push/push.dart';
 import 'package:push_example/text_row.dart';
 
 class RemoteMessageWidget extends StatelessWidget {
-  final RemoteMessage? remoteMessage;
+  final RemoteMessage1? remoteMessage;
 
   const RemoteMessageWidget(this.remoteMessage, {Key? key}) : super(key: key);
 

--- a/push/example/lib/remote_messages_widget.dart
+++ b/push/example/lib/remote_messages_widget.dart
@@ -3,7 +3,7 @@ import 'package:push/push.dart';
 import 'package:push_example/text_row.dart';
 
 class RemoteMessagesWidget extends StatelessWidget {
-  final List<RemoteMessage> remoteMessages;
+  final List<RemoteMessage1> remoteMessages;
 
   const RemoteMessagesWidget(this.remoteMessages, {Key? key}) : super(key: key);
 

--- a/push/lib/push.dart
+++ b/push/lib/push.dart
@@ -3,7 +3,7 @@ library push;
 export 'package:push_platform_interface/push_platform_interface.dart'
     show
         Push,
-        RemoteMessage,
+        RemoteMessage1,
         Notification,
         UNNotificationSettings,
         UNNotificationSetting,

--- a/push/pubspec.yaml
+++ b/push/pubspec.yaml
@@ -4,6 +4,7 @@ version: 2.3.0
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -14,10 +15,10 @@ dependencies:
     sdk: flutter
 
   # Federated package dependencies
-  push_platform_interface: ^0.6.0
-  push_android: ^0.6.0
-  push_ios: ^0.5.1
-  push_macos: ^0.0.1
+  #push_platform_interface: ^0.6.0
+  #push_android: ^0.6.0
+  #push_ios: ^0.5.1
+  #push_macos: ^0.0.1
   # End of federated package dependencies
 
   # When developing push locally, make sure
@@ -28,14 +29,14 @@ dependencies:
 
   # Local development dependencies -
   # uncomment this and comment out the federated package dependencies
-  # push_platform_interface:
-  #   path: "../push_platform_interface"
+  push_platform_interface:
+    path: "../push_platform_interface"
   # push_android:
   #   path: "../push_android"
-  # push_ios:
-  #   path: "../push_ios"
-#    push_macos:
-#      path: "../push_macos"
+  push_ios:
+    path: "../push_ios"
+  # push_macos:
+  #   path: "../push_macos"
 # End of local development dependencies
 
 dev_dependencies:
@@ -51,8 +52,8 @@ flutter:
   uses-material-design: false
   plugin:
     platforms:
-      android:
-        default_package: push_android
+      #android:
+      #  default_package: push_android
       ios:
         default_package: push_ios
   # To add assets to your package, add an assets section, like this:

--- a/push_ios/pubspec.lock
+++ b/push_ios/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -95,10 +95,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:

--- a/push_ios/pubspec.yaml
+++ b/push_ios/pubspec.yaml
@@ -4,6 +4,7 @@ version: 0.5.1
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -14,11 +15,11 @@ dependencies:
     sdk: flutter
 
   # Federated package dependencies
-  push_platform_interface: ^0.6.0
+  # push_platform_interface: ^0.6.0
 
   # Local development dependencies
-  # push_platform_interface:
-    # path: "../push_platform_interface"
+  push_platform_interface:
+    path: "../push_platform_interface"
   # End of local dependencies
 
 dev_dependencies:

--- a/push_platform_interface/lib/push_platform_interface.dart
+++ b/push_platform_interface/lib/push_platform_interface.dart
@@ -9,14 +9,14 @@ import 'package:push_platform_interface/src/serialization/push_api.dart';
 
 export 'src/serialization/push_api.dart'
     show
-        RemoteMessage,
+        RemoteMessage1,
         Notification,
         UNNotificationSettings,
         UNNotificationSetting,
         UNAlertStyle,
         UNAuthorizationStatus;
 
-typedef MessageHandler = FutureOr<void> Function(RemoteMessage message);
+typedef MessageHandler = FutureOr<void> Function(RemoteMessage1 message);
 
 /// The interface that implementations of [`push`](https://pub.dev/packages/push) must implement.
 ///
@@ -180,14 +180,14 @@ class PushFlutterHandlers extends PushFlutterApi {
   }
 
   @override
-  Future<void> onBackgroundMessage(RemoteMessage message) async {
+  Future<void> onBackgroundMessage(RemoteMessage1 message) async {
     for (final handler in push._onBackgroundMessageHandlers) {
       await handler(message);
     }
   }
 
   @override
-  Future<void> onMessage(RemoteMessage message) async {
+  Future<void> onMessage(RemoteMessage1 message) async {
     for (final handler in push._onMessageHandlers) {
       await handler(message);
     }

--- a/push_platform_interface/lib/src/serialization/push_api.dart
+++ b/push_platform_interface/lib/src/serialization/push_api.dart
@@ -69,8 +69,8 @@ enum UNShowPreviewsSetting {
   never,
 }
 
-class RemoteMessage {
-  RemoteMessage({
+class RemoteMessage1 {
+  RemoteMessage1({
     this.notification,
     this.data,
   });
@@ -86,9 +86,9 @@ class RemoteMessage {
     ];
   }
 
-  static RemoteMessage decode(Object result) {
+  static RemoteMessage1 decode(Object result) {
     result as List<Object?>;
-    return RemoteMessage(
+    return RemoteMessage1(
       notification: result[0] != null
           ? Notification.decode(result[0]! as List<Object?>)
           : null,
@@ -231,7 +231,7 @@ class _PushHostApiCodec extends StandardMessageCodec {
     if (value is Notification) {
       buffer.putUint8(128);
       writeValue(buffer, value.encode());
-    } else if (value is RemoteMessage) {
+    } else if (value is RemoteMessage1) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
     } else if (value is UNNotificationSettings) {
@@ -248,7 +248,7 @@ class _PushHostApiCodec extends StandardMessageCodec {
       case 128: 
         return Notification.decode(readValue(buffer)!);
       case 129: 
-        return RemoteMessage.decode(readValue(buffer)!);
+        return RemoteMessage1.decode(readValue(buffer)!);
       case 130: 
         return UNNotificationSettings.decode(readValue(buffer)!);
       default:
@@ -478,7 +478,7 @@ class _PushFlutterApiCodec extends StandardMessageCodec {
     if (value is Notification) {
       buffer.putUint8(128);
       writeValue(buffer, value.encode());
-    } else if (value is RemoteMessage) {
+    } else if (value is RemoteMessage1) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
     } else if (value is UNNotificationSettings) {
@@ -495,7 +495,7 @@ class _PushFlutterApiCodec extends StandardMessageCodec {
       case 128: 
         return Notification.decode(readValue(buffer)!);
       case 129: 
-        return RemoteMessage.decode(readValue(buffer)!);
+        return RemoteMessage1.decode(readValue(buffer)!);
       case 130: 
         return UNNotificationSettings.decode(readValue(buffer)!);
       default:
@@ -507,9 +507,9 @@ class _PushFlutterApiCodec extends StandardMessageCodec {
 abstract class PushFlutterApi {
   static const MessageCodec<Object?> pigeonChannelCodec = _PushFlutterApiCodec();
 
-  Future<void> onMessage(RemoteMessage message);
+  Future<void> onMessage(RemoteMessage1 message);
 
-  Future<void> onBackgroundMessage(RemoteMessage message);
+  Future<void> onBackgroundMessage(RemoteMessage1 message);
 
   /// Unfortunately, the intent provided to the app when a user taps on a
   /// notification does not include notification's title or body.
@@ -538,7 +538,7 @@ abstract class PushFlutterApi {
           assert(message != null,
           'Argument for dev.flutter.pigeon.push_platform_interface.PushFlutterApi.onMessage was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final RemoteMessage? arg_message = (args[0] as RemoteMessage?);
+          final RemoteMessage1? arg_message = (args[0] as RemoteMessage1?);
           assert(arg_message != null,
               'Argument for dev.flutter.pigeon.push_platform_interface.PushFlutterApi.onMessage was null, expected non-null RemoteMessage.');
           try {
@@ -563,7 +563,7 @@ abstract class PushFlutterApi {
           assert(message != null,
           'Argument for dev.flutter.pigeon.push_platform_interface.PushFlutterApi.onBackgroundMessage was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final RemoteMessage? arg_message = (args[0] as RemoteMessage?);
+          final RemoteMessage1? arg_message = (args[0] as RemoteMessage1?);
           assert(arg_message != null,
               'Argument for dev.flutter.pigeon.push_platform_interface.PushFlutterApi.onBackgroundMessage was null, expected non-null RemoteMessage.');
           try {


### PR DESCRIPTION
- using this as local package in the app folder as `packages/push`
- updated the package from federated package depencies to local package dependences and disabling `publish_to` in the pubspec.yaml
- there was a class collision with Firebase's `RemoteMessage` and refactored push's to `RemoteMessage1`
- updated README.md with fork changes as we go.

NOTE: this hasn't been fulled integrated with an app yet, but does compile without issues now.